### PR TITLE
add two more ddb table examples

### DIFF
--- a/lib/constructs/lambda/seed-function/data/dynamodb-v1.csv
+++ b/lib/constructs/lambda/seed-function/data/dynamodb-v1.csv
@@ -1,4 +1,4 @@
-id,age,city,height,mobile,state,username
+user_id,age,city,height,mobile,state,username
 1,33,Seattle,,,WA,mathew
 2,30,null,,,AZ,sam
 3,null,Mesa,,,AZ,pam

--- a/lib/constructs/lambda/seed-function/data/dynamodb-v2.csv
+++ b/lib/constructs/lambda/seed-function/data/dynamodb-v2.csv
@@ -1,0 +1,9 @@
+user_id,sk,name,age,state,item,qty,unitPrice
+1,info,mat,31,WA,,,
+2,info,sam,30,AZ,,,
+3,info,jane,50,NY,,,
+4,info,kimiko,36,CA,,,
+1,order100#line001,,,,22134,5, 5.00 
+1,order100#line002,,,,23042,1,24.99
+2,order102#line001,,,,99000,20,2.99
+4,order103#line001,,,,48953,50,1.5

--- a/lib/constructs/lambda/seed-function/data/dynamodb-v3.csv
+++ b/lib/constructs/lambda/seed-function/data/dynamodb-v3.csv
@@ -1,0 +1,13 @@
+pk,sk,name,age,state,item,qty,unitPrice
+user#1,info,mat,31,WA,,,
+user#2,info,sam,30,AZ,,,
+user#3,info,jane,50,NY,,,
+user#4,info,kimiko,36,CA,,,
+user#1,order100#line001,,,,A100,5,5
+user#1,order100#line002,,,,D302,1,24.99
+user#2,order102#line001,,,,G332,20,2.99
+user#4,order103#line001,,,,A402,50,1.5
+item#A100,info,Widget,,,,,
+item#D302,info,Sprocket,,,,,
+item#G332,info,Nail,,,,,
+item#A402,info,Small Spring,,,,,

--- a/lib/constructs/lambda/seed-function/index.js
+++ b/lib/constructs/lambda/seed-function/index.js
@@ -8,7 +8,9 @@ const dynamo = new AWS.DynamoDB.DocumentClient({});
 const PARAMETERS = {
     SqlDatabaseSecretArn: process.env.SqlDatabaseSecretArn,
     SqlDatabaseArn: process.env.SqlDatabaseArn,
-    DynamoTableNameV1: process.env.DynamoTableNameV1
+    DynamoTableNameV1: process.env.DynamoTableNameV1,
+    DynamoTableNameV2: process.env.DynamoTableNameV2,
+    DynamoTableNameV3: process.env.DynamoTableNameV3
 };
 
 exports.handler = async (event, context) => {
@@ -24,6 +26,8 @@ exports.handler = async (event, context) => {
         if (event.RequestType === 'Create' || event.RequestType === 'Update') {
             await seedRds();
             await seedDynamo('data/dynamodb-v1.csv', PARAMETERS.DynamoTableNameV1);
+            await seedDynamo('data/dynamodb-v2.csv', PARAMETERS.DynamoTableNameV2);
+            await seedDynamo('data/dynamodb-v3.csv', PARAMETERS.DynamoTableNameV3);
             physicalResourceId = event.LogicalResourceId; // we aren't creating any new resources, so can just use logical ID as physical ID
         }
         else if (event.RequestType === 'Delete') {
@@ -91,7 +95,7 @@ const seedDynamo = async(csvFilePath, tableName) => {
 
     let first = 0;
     const totalItems = newItems.length;
-    console.log(`Items to write ${totalItems}`);
+    console.log(`Items to write ${totalItems} to ${tableName}`);
     while (true){
         if (first > totalItems){
             break;


### PR DESCRIPTION
Added two additional DynamoDB tables, with the idea being: 

* Table 1 = more or less identical to relational conceptual model, i.e. single table = single entity type (users)
* Table 2 = add in sort key to model many:1 relationships, e.g. users -> orders. 
* Table 3 = rename partition key from "user_id" to "pk". This drives home the point that a single table can contain many standalone entity types (DDB best practice where it makes sense). 

I think three tables is enough. If we want to layer on additional best practices/examples, such as GSIs, I think we can leverage one of the tables above. 

I renamed "id" to "user_id" in table one just to make the "single table = single entity" concept more clear. Since changing partition key requires resource recreation and you can't recreate custom-named resources, I had to change the logical resource name of table1 as well. 

Tested via redeployment, worked as expected. 